### PR TITLE
Make sure required directories exist

### DIFF
--- a/dev/CMakeLists.txt
+++ b/dev/CMakeLists.txt
@@ -133,3 +133,5 @@ file(GLOB SHADERS
   "${PROJECT_SOURCE_DIR}/ressources/*")
 
 file(COPY ${SHADERS} DESTINATION ${CMAKE_BINARY_DIR}/ressources)
+file(MAKE_DIRECTORY ${CMAKE_BINARY_DIR}/ressources/Grids/Saves)
+file(MAKE_DIRECTORY ${CMAKE_BINARY_DIR}/ressources/Grids/Finished)


### PR DESCRIPTION
I found that the game crashes when going to the level selection and when a puzzle is started because some required directories are not created by default when building with CMake.

I also do not know what's up with the way text displays, so I still cannot really play it on my machine, but I'll look into that later.